### PR TITLE
Add reusable Claude code review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,65 @@
-# .github
-# .github
-# .github
+# Totetech Organization GitHub Workflows
+
+This repository contains reusable GitHub workflows and templates for the Totetech organization.
+
+## Claude Code Review Workflow
+
+Automated code review using Claude AI for pull requests.
+
+### Usage
+
+To use the Claude code review workflow in your repository:
+
+1. Create `.github/workflows/claude-review.yml` in your repository
+2. Add the following content:
+
+```yaml
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, edited]
+
+jobs:
+  claude-review:
+    uses: totetech/.github/.github/workflows/claude-code-review.yml@main
+    with:
+      skip_large_prs: true
+      max_files: 50
+      max_lines: 2000
+```
+
+### Configuration Options
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| `skip_large_prs` | Skip review for large PRs | `true` |
+| `max_files` | Maximum files to trigger review | `50` |
+| `max_lines` | Maximum lines changed to trigger review | `2000` |
+| `custom_prompt` | Custom review prompt (optional) | Default prompt |
+
+### Features
+
+- ✅ Automatic PR size labeling (XS/S/M/L)
+- ✅ Skips review for draft PRs and bot PRs
+- ✅ Collapses previous review comments
+- ✅ Configurable size limits
+- ✅ Custom review prompts
+- ✅ Skip review with `skip-review` label
+
+### Prerequisites
+
+- Organization-level `ANTHROPIC_API_KEY` secret must be configured
+- Repositories must have appropriate permissions for the workflow
+
+### Example with Custom Prompt
+
+```yaml
+jobs:
+  claude-review:
+    uses: totetech/.github/.github/workflows/claude-code-review.yml@main
+    with:
+      custom_prompt: |
+        Focus on security vulnerabilities and performance issues.
+        Pay special attention to database queries and API endpoints.
+```

--- a/workflow-templates/claude-code-review.properties.json
+++ b/workflow-templates/claude-code-review.properties.json
@@ -1,0 +1,12 @@
+{
+  "name": "Claude Code Review",
+  "description": "Automated code review using Claude AI for pull requests",
+  "iconName": "code-review",
+  "categories": [
+    "Code Quality",
+    "Continuous Integration"
+  ],
+  "filePatterns": [
+    ".github/workflows/claude-review.yml"
+  ]
+}

--- a/workflow-templates/claude-code-review.yml
+++ b/workflow-templates/claude-code-review.yml
@@ -1,0 +1,16 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, edited]
+
+jobs:
+  claude-review:
+    uses: totetech/.github/.github/workflows/claude-code-review.yml@main
+    with:
+      skip_large_prs: true
+      max_files: 50
+      max_lines: 2000
+      # custom_prompt: |
+      #   Add your custom review prompt here if needed
+      #   This will override the default prompt

--- a/workflows/claude-code-review.yml
+++ b/workflows/claude-code-review.yml
@@ -1,0 +1,229 @@
+name: Claude Code Review
+
+on:
+  workflow_call:
+    inputs:
+      skip_large_prs:
+        description: 'Skip review for PRs with more than 50 files or 2000 lines'
+        required: false
+        type: boolean
+        default: true
+      max_files:
+        description: 'Maximum number of files to trigger review'
+        required: false
+        type: number
+        default: 50
+      max_lines:
+        description: 'Maximum number of lines changed to trigger review'
+        required: false
+        type: number
+        default: 2000
+      custom_prompt:
+        description: 'Custom review prompt (optional)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-code-review:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Check PR size
+        id: pr-size
+        run: |
+          FILES_CHANGED=$(git diff --name-only HEAD~1 | wc -l)
+          LINES_CHANGED=$(git diff --shortstat HEAD~1 | grep -oE '[0-9]+ insertions|[0-9]+ deletions' | grep -oE '[0-9]+' | paste -sd+ | bc || echo 0)
+          
+          echo "files_changed=$FILES_CHANGED" >> $GITHUB_OUTPUT
+          echo "lines_changed=$LINES_CHANGED" >> $GITHUB_OUTPUT
+          
+          if [ "${{ inputs.skip_large_prs }}" == "true" ] && ([ "$FILES_CHANGED" -gt ${{ inputs.max_files }} ] || [ "$LINES_CHANGED" -gt ${{ inputs.max_lines }} ]); then
+            echo "skip_review=true" >> $GITHUB_OUTPUT
+            echo "⚠️ PR is too large for automated review (${FILES_CHANGED} files, ${LINES_CHANGED} lines changed)"
+          else
+            echo "skip_review=false" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Add PR size label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const filesChanged = ${{ steps.pr-size.outputs.files_changed || 0 }};
+            const linesChanged = ${{ steps.pr-size.outputs.lines_changed || 0 }};
+            
+            let sizeLabel = 'size/XS';
+            if (linesChanged > 500 || filesChanged > 10) sizeLabel = 'size/L';
+            else if (linesChanged > 100 || filesChanged > 5) sizeLabel = 'size/M';
+            else if (linesChanged > 30 || filesChanged > 2) sizeLabel = 'size/S';
+            
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [sizeLabel]
+            });
+            
+      - name: Comment on large PR
+        if: steps.pr-size.outputs.skip_review == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 🤖 Claude Review Skipped
+              
+              This PR is too large for automated review (${{ steps.pr-size.outputs.files_changed }} files, ${{ steps.pr-size.outputs.lines_changed }} lines changed).
+              
+              Consider:
+              - Breaking this into smaller, focused PRs
+              - Requesting manual review from team members
+              - Using the \`skip-review\` label for intentionally large changes
+              
+              *Automated reviews work best with PRs under ${{ inputs.max_files }} files and ${{ inputs.max_lines }} lines of changes.*`
+            });
+            
+      - name: Collapse previous Claude comments
+        if: steps.pr-size.outputs.skip_review == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            
+            console.log(`📊 DEBUG: Found ${comments.data.length} total comments on PR`);
+            
+            let claudeCommentsFound = 0;
+            let claudeCommentsCollapsed = 0;
+            let claudeCommentsSkipped = 0;
+            let collapsedAttempts = 0;
+            
+            for (const [index, comment] of comments.data.entries()) {
+              const isBot = comment.user.login === 'github-actions[bot]';
+              const hasClaudeFinished = comment.body.includes('Claude finished') || comment.body.includes('**Claude finished');
+              const hasDetails = comment.body.trim().startsWith('<details><summary>');
+              
+              console.log(`📝 Comment ${index + 1}:`);
+              console.log(`   - ID: ${comment.id}`);
+              console.log(`   - User: ${comment.user.login}`);
+              console.log(`   - Created: ${comment.created_at}`);
+              console.log(`   - Is Bot: ${isBot}`);
+              console.log(`   - Has Claude finished: ${hasClaudeFinished}`);
+              console.log(`   - Has details: ${hasDetails}`);
+              console.log(`   - Body preview: ${comment.body.substring(0, 100)}...`);
+              
+              if (isBot && hasClaudeFinished) {
+                claudeCommentsFound++;
+                
+                if (!hasDetails) {
+                  collapsedAttempts++;
+                  console.log(`✅ COLLAPSING Comment ${comment.id}`);
+                  
+                  if (index > 0 && index % 10 === 0) {
+                    await new Promise(resolve => setTimeout(resolve, 100));
+                  }
+                  
+                  const attemptNumber = collapsedAttempts;
+                  console.log(`🔢 DEBUG: Using attempt number ${attemptNumber} for comment ${comment.id}`);
+                  const wrappedBody = `<details><summary>Previous Claude Review (Attempt #${attemptNumber})</summary>\n\n${comment.body}\n\n</details>`;
+                  
+                  try {
+                    await github.rest.issues.updateComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: comment.id,
+                      body: wrappedBody
+                    });
+                    claudeCommentsCollapsed++;
+                    console.log(`✅ Successfully collapsed comment ${comment.id}`);
+                  } catch (error) {
+                    console.log(`❌ Failed to collapse comment ${comment.id}: ${error.message}`);
+                  }
+                } else {
+                  claudeCommentsSkipped++;
+                  console.log(`⏭️ SKIPPING Comment ${comment.id} (already has details)`);
+                }
+              }
+            }
+            
+            console.log(`📈 SUMMARY:`);
+            console.log(`   - Total comments: ${comments.data.length}`);
+            console.log(`   - Claude comments found: ${claudeCommentsFound}`);
+            console.log(`   - Claude comments collapsed: ${claudeCommentsCollapsed}`);
+            console.log(`   - Claude comments skipped: ${claudeCommentsSkipped}`);
+            
+      - name: Automatic PR Review
+        if: steps.pr-size.outputs.skip_review == 'false'
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          direct_prompt: |
+            ${{ inputs.custom_prompt != '' && inputs.custom_prompt || 'You are an experienced software engineer tasked with reviewing a GitHub pull request. Your goal is to provide valuable feedback to improve code quality, catch potential issues, and ensure the changes align with best practices.
+
+            Here''s the pull request description:
+            <pr_description>
+            {{PR_DESCRIPTION}}
+            </pr_description>
+
+            Here''s the diff of changes:
+            <diff>
+            {{DIFF}}
+            </diff>
+
+            If this is a subsequent review, here''s the previous review:
+            <previous_review>
+            {{PREVIOUS_REVIEW}}
+            </previous_review>
+
+            For the FIRST review (new PR):
+            1. Carefully examine all aspects of the code changes.
+            2. Provide comprehensive feedback on code quality, functionality, and adherence to best practices.
+            3. Identify any potential bugs, security issues, or performance concerns.
+            4. Suggest improvements or alternative approaches where applicable.
+            5. Comment on documentation and test coverage.
+
+            For SUBSEQUENT reviews (new commits/edits):
+            1. Focus primarily on new or modified code since the last review.
+            2. Evaluate how the changes address previous feedback.
+            3. Identify any critical issues such as bugs, security vulnerabilities, or breaking changes.
+            4. If the review was triggered by a PR description edit, pay attention to context changes that affect code understanding.
+            5. Skip re-reviewing unchanged code unless it''s directly affected by new changes.
+
+            General guidelines for all reviews:
+            1. Be concise and focus on actionable feedback.
+            2. Prioritize critical issues over minor stylistic concerns.
+            3. Provide clear explanations for your suggestions or concerns.
+            4. If applicable, reference relevant documentation or best practices.
+            5. Maintain a constructive and respectful tone throughout the review.
+
+            Your review should be structured as follows:
+            1. Summary: Provide a brief overview of the changes and your overall assessment.
+            2. Major Concerns: List any critical issues that must be addressed before merging.
+            3. Minor Suggestions: Offer less critical recommendations for improving the code.
+            4. Positive Feedback: Highlight well-implemented parts of the code or good practices used.
+            5. Follow-up Questions: Ask for clarification on any unclear aspects of the changes.
+
+            Write your review inside <review> tags. Ensure your final output includes only the content of the review, without any additional commentary or repetition of these instructions.' }}


### PR DESCRIPTION
## Summary
- Add reusable Claude code review workflow for organization-wide use
- Create workflow template for easy adoption across repositories
- Include comprehensive documentation and configuration options

## Features
- Configurable PR size limits (default: 50 files, 2000 lines)
- Automatic PR size labeling (XS/S/M/L)
- Previous review comment collapsing
- Custom review prompt support
- Skip conditions for drafts, bots, and large PRs

## Test plan
- [ ] Test workflow in a sample repository
- [ ] Verify organization-level ANTHROPIC_API_KEY works
- [ ] Test different configuration options
- [ ] Verify PR size labeling works correctly