### PR TITLE
Enable Claude code review for this repository

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,13 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, edited]
+
+jobs:
+  claude-review:
+    uses: ./.github/workflows/claude-code-review.yml
+    with:
+      skip_large_prs: true
+      max_files: 50
+      max_lines: 2000


### PR DESCRIPTION
## Summary
Enable Claude code review workflow for this .github repository itself

## Changes
- Add `.github/workflows/claude-review.yml` that uses the reusable workflow
- This will enable automated code reviews for future PRs to this repository

## Test plan
- [ ] Verify workflow runs on this PR
- [ ] Check that Claude review comment appears
- [ ] Ensure workflow uses correct configuration