### PR TITLE
Add shared gcloud-auth and docker-build actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Shared GitHub Actions — platform team approval required
+actions/                @jatin-toteai
+workflows/              @jatin-toteai @gaurish

--- a/actions/README.md
+++ b/actions/README.md
@@ -23,7 +23,7 @@ steps:
     with:
       workload_identity_provider: 'projects/<project-number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>'
       service_account: '<sa-name>@<project>.iam.gserviceaccount.com'
-      access_token_lifetime: '1800'  # optional, default 30 min
+      access_token_lifetime: '1800s'  # optional, default 30 min
       region: 'us-central1'          # optional, for Docker registry auth
 ```
 
@@ -34,7 +34,7 @@ steps:
 | `workload_identity_provider` | Yes | — | WIF provider resource path |
 | `service_account` | Yes | — | Service account email |
 | `token_format` | No | `access_token` | Token format to request |
-| `access_token_lifetime` | No | `1800` | Token lifetime in seconds |
+| `access_token_lifetime` | No | `1800s` | Token lifetime as Go-style duration string |
 | `region` | No | `us-central1` | Artifact Registry region for Docker auth |
 
 ### `docker-build` — Build and Push to Artifact Registry

--- a/actions/README.md
+++ b/actions/README.md
@@ -1,0 +1,101 @@
+# Shared GitHub Actions
+
+Reusable composite actions for the totetech organization. These actions contain **no project-specific defaults** — all sensitive values (GCP project IDs, service accounts, registry paths) must be passed by the consuming workflow.
+
+## Actions
+
+### `gcloud-auth` — GCP Authentication via OIDC
+
+Authenticates to Google Cloud using Workload Identity Federation. No long-lived service account keys.
+
+**Usage:**
+
+```yaml
+permissions:
+  contents: read
+  id-token: write  # Required for OIDC
+
+steps:
+  - uses: actions/checkout@v4
+
+  - name: Authenticate to Google Cloud
+    uses: totetech/.github/actions/gcloud-auth@<sha>
+    with:
+      workload_identity_provider: 'projects/<project-number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>'
+      service_account: '<sa-name>@<project>.iam.gserviceaccount.com'
+      access_token_lifetime: '1800'  # optional, default 30 min
+      region: 'us-central1'          # optional, for Docker registry auth
+```
+
+**Inputs:**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `workload_identity_provider` | Yes | — | WIF provider resource path |
+| `service_account` | Yes | — | Service account email |
+| `token_format` | No | `access_token` | Token format to request |
+| `access_token_lifetime` | No | `1800` | Token lifetime in seconds |
+| `region` | No | `us-central1` | Artifact Registry region for Docker auth |
+
+### `docker-build` — Build and Push to Artifact Registry
+
+Builds a Docker image with Buildx, pushes to GCP Artifact Registry with GitHub Actions layer caching.
+
+**Usage:**
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+
+  - name: Authenticate to Google Cloud
+    uses: totetech/.github/actions/gcloud-auth@<sha>
+    with:
+      workload_identity_provider: '...'
+      service_account: '...'
+
+  - name: Build and push
+    id: docker-build
+    uses: totetech/.github/actions/docker-build@<sha>
+    with:
+      image_name: 'my-repo/my-image'
+      ar_registry: 'us-central1-docker.pkg.dev/my-project'
+```
+
+**Inputs:**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `image_name` | Yes | — | Image path in registry (e.g. `repo/image`) |
+| `ar_registry` | Yes | — | Artifact Registry base path (e.g. `us-central1-docker.pkg.dev/project-id`) |
+| `folder` | No | `.` | Build context directory |
+
+**Outputs:**
+
+| Output | Description |
+|--------|-------------|
+| `image_tag` | Full image tag that was pushed (`registry/repo/image:branch-sha`) |
+| `digest` | Image digest (`sha256:...`) for pinning or signing |
+
+**Features:**
+- Docker Buildx with multi-layer caching (`type=gha, mode=max`)
+- Branch-based tagging (`<branch>-<commit-sha>`)
+- Build summary in GitHub Actions step summary (JSON)
+- Build artifact uploaded (30-day retention)
+
+## Security
+
+- **No defaults with sensitive values** — all GCP identifiers must be passed explicitly
+- **Pin by SHA** — always reference `@<commit-sha>`, not `@main`, for production workflows
+- **CODEOWNERS** — changes to `actions/` require `@jatin-toteai` approval
+
+## Versioning
+
+Pin actions to a specific commit SHA for stability:
+
+```yaml
+# Pinned (recommended for production)
+uses: totetech/.github/actions/gcloud-auth@abc1234def5678
+
+# Branch reference (acceptable for development)
+uses: totetech/.github/actions/gcloud-auth@main
+```

--- a/actions/docker-build/action.yml
+++ b/actions/docker-build/action.yml
@@ -1,0 +1,93 @@
+name: 'Docker Build and Push'
+description: 'Builds a Docker image with Buildx and pushes to Artifact Registry with GHA layer caching'
+author: 'Tote Tech'
+
+inputs:
+  image_name:
+    description: 'Full image path in Artifact Registry (e.g. repo/image)'
+    required: true
+  ar_registry:
+    description: 'Artifact Registry base path (e.g. us-central1-docker.pkg.dev/project-id)'
+    required: true
+  folder:
+    description: 'Build context folder'
+    required: false
+    default: '.'
+
+outputs:
+  image_tag:
+    description: 'Full image tag that was pushed'
+    value: ${{ steps.tags.outputs.image_tag }}
+  digest:
+    description: 'Image digest (sha256)'
+    value: ${{ steps.summary.outputs.digest }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Compute image tag
+      id: tags
+      run: |
+        BRANCH_NAME=${GITHUB_REF#refs/heads/}
+        BRANCH_NAME=${BRANCH_NAME//\//-}
+        BRANCH_NAME=${BRANCH_NAME:0:25}
+        IMAGE_TAG="${{ inputs.ar_registry }}/${{ inputs.image_name }}:${BRANCH_NAME}-${{ github.sha }}"
+        echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+        echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: ${{ inputs.folder }}
+        push: true
+        tags: ${{ steps.tags.outputs.image_tag }}
+        build-args: |
+          GITHUB_SHA=${{ github.sha }}
+          GITHUB_REF=${{ github.ref }}
+        cache-from: type=gha,scope=${{ inputs.image_name }}
+        cache-to: type=gha,scope=${{ inputs.image_name }},mode=max
+
+    - name: Build summary
+      id: summary
+      run: |
+        DIGEST="${{ steps.build.outputs.digest }}"
+        IMAGE_TAG="${{ steps.tags.outputs.image_tag }}"
+        BRANCH_NAME="${{ steps.tags.outputs.branch_name }}"
+
+        BUILD_RESULT=$(jq -n \
+          --arg image_name "${{ inputs.image_name }}" \
+          --arg image_tag "$IMAGE_TAG" \
+          --arg branch "$BRANCH_NAME" \
+          --arg sha "${{ github.sha }}" \
+          --arg digest "$DIGEST" \
+          '{
+            image_name: $image_name,
+            image_tag: $image_tag,
+            branch: $branch,
+            sha: $sha,
+            digest: $digest
+          }')
+
+        echo "## Build Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo '```json' >> $GITHUB_STEP_SUMMARY
+        echo "$BUILD_RESULT" | jq '.' >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+
+        mkdir -p "$GITHUB_WORKSPACE/.github/build-info"
+        echo "$BUILD_RESULT" > "$GITHUB_WORKSPACE/.github/build-info/${{ github.run_id }}-build.json"
+
+        echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-info-${{ github.run_id }}
+        path: .github/build-info/${{ github.run_id }}-build.json
+        retention-days: 30

--- a/actions/docker-build/action.yml
+++ b/actions/docker-build/action.yml
@@ -31,7 +31,11 @@ runs:
     - name: Compute image tag
       id: tags
       run: |
-        BRANCH_NAME=${GITHUB_REF#refs/heads/}
+        if [[ -n "$GITHUB_HEAD_REF" ]]; then
+          BRANCH_NAME="$GITHUB_HEAD_REF"
+        else
+          BRANCH_NAME="$GITHUB_REF_NAME"
+        fi
         BRANCH_NAME=${BRANCH_NAME//\//-}
         BRANCH_NAME=${BRANCH_NAME:0:25}
         IMAGE_TAG="${{ inputs.ar_registry }}/${{ inputs.image_name }}:${BRANCH_NAME}-${{ github.sha }}"

--- a/actions/gcloud-auth/action.yml
+++ b/actions/gcloud-auth/action.yml
@@ -1,0 +1,41 @@
+name: 'Authenticate to Google Cloud'
+description: 'Authenticates GitHub Actions runner with Google Cloud via OIDC Workload Identity Federation'
+author: 'Tote Tech'
+
+inputs:
+  workload_identity_provider:
+    description: 'Workload Identity Provider resource path'
+    required: true
+  service_account:
+    description: 'Service Account Email for authentication'
+    required: true
+  token_format:
+    description: 'Token format to request'
+    required: false
+    default: 'access_token'
+  access_token_lifetime:
+    description: 'Access token lifetime in seconds'
+    required: false
+    default: '1800'
+  region:
+    description: 'Artifact Registry region for Docker auth'
+    required: false
+    default: 'us-central1'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.service_account }}
+        token_format: ${{ inputs.token_format }}
+        access_token_lifetime: ${{ inputs.access_token_lifetime }}
+
+    - name: Configure Docker
+      run: gcloud auth configure-docker "${{ inputs.region }}-docker.pkg.dev" --quiet
+      shell: bash

--- a/actions/gcloud-auth/action.yml
+++ b/actions/gcloud-auth/action.yml
@@ -14,9 +14,9 @@ inputs:
     required: false
     default: 'access_token'
   access_token_lifetime:
-    description: 'Access token lifetime in seconds'
+    description: 'Access token lifetime as a Go-style duration string (e.g. 1800s)'
     required: false
-    default: '1800'
+    default: '1800s'
   region:
     description: 'Artifact Registry region for Docker auth'
     required: false
@@ -25,9 +25,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
-
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
       with:
@@ -35,6 +32,9 @@ runs:
         service_account: ${{ inputs.service_account }}
         token_format: ${{ inputs.token_format }}
         access_token_lifetime: ${{ inputs.access_token_lifetime }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Configure Docker
       run: gcloud auth configure-docker "${{ inputs.region }}-docker.pkg.dev" --quiet


### PR DESCRIPTION
## Summary

Adds two reusable composite actions for org-wide use, so individual repos don't duplicate GCP auth and Docker build logic.

### Actions Added

**`actions/gcloud-auth`** — OIDC Workload Identity Federation auth
- All inputs **required** (no project-specific defaults)
- Consuming repos pass their own WIF provider, service account, and region
- Configurable token lifetime (default 30min)

**`actions/docker-build`** — Buildx build + push to Artifact Registry
- All inputs **required** (no registry defaults)
- GHA layer caching (`type=gha, mode=max`)
- Branch-based tagging (`<branch>-<sha>`)
- Build summary in `GITHUB_STEP_SUMMARY`
- Proper `outputs` for `image_tag` and `digest`
- Build artifact upload

### Usage

```yaml
- uses: totetech/.github/actions/gcloud-auth@<sha>
  with:
    workload_identity_provider: 'projects/123/locations/global/...'
    service_account: 'sa@project.iam.gserviceaccount.com'

- uses: totetech/.github/actions/docker-build@<sha>
  with:
    image_name: 'repo/image'
    ar_registry: 'us-central1-docker.pkg.dev/project-id'
```

### Security

- No project IDs, service accounts, or WIF providers in this public repo
- All sensitive values passed by consuming repos (private/internal)
- CODEOWNERS added: `actions/` requires `@jatin-toteai` approval
- Consuming repos should pin by SHA, not `@main`

### First Consumer

`totetech/Tote-PaymentGateway` PR #1 will switch to these shared actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new reusable CI actions for GCP authentication and Artifact Registry image publishing; while additive, mistakes in these workflows could impact org-wide build/deploy and credentials usage once adopted.
> 
> **Overview**
> Introduces **org-wide reusable GitHub composite actions** under `actions/` for Google Cloud OIDC authentication (`gcloud-auth`) and Docker Buildx build+push to Artifact Registry (`docker-build`), including branch-based tagging, GHA cache configuration, and emitting build metadata (step summary + uploaded artifact).
> 
> Adds documentation (`actions/README.md`) for usage/inputs/outputs and updates `.github/CODEOWNERS` to require platform review for changes to `actions/` (and owners for `workflows/`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b6f4bd4f16c3a02d734d72082855d1ad8d61d77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->